### PR TITLE
hal: wch: update HAL to latest upstream (2026-05)

### DIFF
--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -967,7 +967,7 @@ RV_STATIC_INLINE void funPinMode(u32 pin, GPIOModeTypeDef mode)
 #define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC ); }
 #define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
 #elif defined(CH32V10x) || defined(CH32V20x) || defined(CH32V30x) || defined(CH32L103)
-#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOD ); }
+#define funGpioInitAll() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOA | RCC_APB2Periph_GPIOB | RCC_APB2Periph_GPIOC | RCC_APB2Periph_GPIOD | RCC_APB2Periph_GPIOE ); }
 #define funPinMode( pin, mode ) { *((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3)) = ( (*((&GpioOf(pin)->CFGLR)+((pin&0x8)>>3))) & (~(0xf<<(4*((pin)&0x7))))) | ((mode)<<(4*((pin)&0x7))); }
 #define funGpioInitB() { RCC->APB2PCENR |= ( RCC_APB2Periph_AFIO | RCC_APB2Periph_GPIOB ); }
 #elif defined(CH32H41x)
@@ -1050,13 +1050,14 @@ uint64_t funSysTick64( void );
 #ifndef __MACOSX__
 #ifndef __DELAY_TINY_DEFINED__
 #define __DELAY_TINY_DEFINED__
+
 static inline void Delay_Tiny( int n ) {
-	__ASM volatile( "\
-		mv a5, %[n]\n\
+	asm volatile( "\
 		1: \
-		c.addi a5, -1\n\
-		c.bnez a5, 1b" : : [n]"r"(n) : "a5" );
+		c.addi %[n], -1\n\
+		c.bnez %[n], 1b" : [n]"+r"(n) );
 }
+
 #endif
 #endif
 #endif //defined(__riscv) || defined(__riscv__) || defined( CH32V003FUN_BASE )

--- a/ch32fun/ch32v30xhw.h
+++ b/ch32fun/ch32v30xhw.h
@@ -10586,6 +10586,22 @@ typedef struct
 #define PD13 61
 #define PD14 62
 #define PD15 63
+#define	PE0	64
+#define	PE1	65
+#define	PE2	66
+#define	PE3	67
+#define	PE4	68
+#define	PE5	69
+#define	PE6	70
+#define	PE7	71
+#define	PE8	72
+#define	PE9	73
+#define	PE10 74
+#define	PE11 75
+#define	PE12 76
+#define	PE13 77
+#define	PE14 78
+#define	PE15 79
 
 /*
  * This file contains various parts of the official WCH EVT Headers which

--- a/ch32fun/ch32x00xhw.h
+++ b/ch32fun/ch32x00xhw.h
@@ -95,7 +95,9 @@ typedef enum IRQn
 	.word   TIM1_TRG_COM_IRQHandler   /* TIM1 Trigger and Commutation */   \n\
 	.word   TIM1_CC_IRQHandler        /* TIM1 Capture Compare */           \n\
 	.word   TIM2_IRQHandler           /* TIM2 */                           \n\
-	.option   pop;\n"
+	.word   USART2_IRQHandler         /* USART2 */                         \n\
+    .word   OPCM_IRQHandler           /* OPCM */                           \n\
+    .option   pop;\n"
 
 
 /* memory mapped structure for SysTick */
@@ -782,6 +784,10 @@ typedef struct
 /*******************  Bit definition for ADC_CTLR2 register  ********************/
 #define ADC_ADON                                ((uint32_t)0x00000001) /* A/D Converter ON / OFF */
 #define ADC_CONT                                ((uint32_t)0x00000002) /* Continuous Conversion */
+
+#define ADC_CAL                                 ((uint32_t)0x00000004) /* Calibrate */
+#define ADC_RSTCAL                              ((uint32_t)0x00000008) /* Reset Calibration */
+
 #define ADC_TGREGU                              ((uint32_t)0x00000010) /* External trigger event of rule channel conversion */
 #define ADC_TGINJE                              ((uint32_t)0x00000020) /* External trigger event of injection channel conversion */
 #define ADC_DMA                                 ((uint32_t)0x00000100) /* Direct Memory access mode */
@@ -799,13 +805,13 @@ typedef struct
 #define ADC_EXTSEL_1                            ((uint32_t)0x00040000) /* Bit 1 */
 #define ADC_EXTSEL_2                            ((uint32_t)0x00080000) /* Bit 2 */
 #define ADC_EXTSEL_TRGO_1						((uint32_t)0x00000000) /* TRGO event of timer 1 		*/
-#define ADC_EXTSEL_CC1_1						((uint32_t)0x00000000) /* CC1 event of timer 1 			*/
-#define ADC_EXTSEL_CC2_1						((uint32_t)0x00000000) /* CC2 event of timer 1 			*/
-#define ADC_EXTSEL_TRGO_2						((uint32_t)0x00000000) /* TRGO event of timer 2 		*/
-#define ADC_EXTSEL_CC1_2						((uint32_t)0x00000000) /* CC1 event of timer 2 			*/
-#define ADC_EXTSEL_CC2_2						((uint32_t)0x00000000) /* CC2 event of timer 2 			*/
-#define ADC_EXTSEL_OPA							((uint32_t)0x00000000) /* OPA trigger/(PD3/PC2) 		*/
-#define ADC_EXTSEL_SWSTART						((uint32_t)0x00000000) /* SWSTART software trigger 	*/
+#define ADC_EXTSEL_CC1_1						((uint32_t)0x00020000) /* CC1 event of timer 1 			*/
+#define ADC_EXTSEL_CC2_1						((uint32_t)0x00040000) /* CC2 event of timer 1 			*/
+#define ADC_EXTSEL_TRGO_2						((uint32_t)0x00060000) /* TRGO event of timer 2 		*/
+#define ADC_EXTSEL_CC1_2						((uint32_t)0x00080000) /* CC1 event of timer 2 			*/
+#define ADC_EXTSEL_CC2_2						((uint32_t)0x000A0000) /* CC2 event of timer 2 			*/
+#define ADC_EXTSEL_OPA							((uint32_t)0x000C0000) /* OPA trigger/(PD3/PC2) 		*/
+#define ADC_EXTSEL_SWSTART						((uint32_t)0x000E0000) /* SWSTART software trigger 	*/
 
 #define ADC_EXTTRIG                             ((uint32_t)0x00100000) /* External Trigger Conversion mode for regular channels */
 #define ADC_JSWSTART                            ((uint32_t)0x00200000) /* Start Conversion of injected channels */
@@ -2481,6 +2487,7 @@ typedef struct
 #define TIM2_DMAINTENR_CC2DE                    ((uint16_t)0x0400) /* Capture/Compare 2 DMA request enable */
 #define TIM2_DMAINTENR_CC3DE                    ((uint16_t)0x0800) /* Capture/Compare 3 DMA request enable */
 #define TIM2_DMAINTENR_CC4DE                    ((uint16_t)0x1000) /* Capture/Compare 4 DMA request enable */
+#define TIM2_DMAINTENR_COMDE                    ((uint16_t)0x2000) /* COM DMA request enable */
 #define TIM2_DMAINTENR_TDE                      ((uint16_t)0x4000) /* Trigger DMA request enable */
 
 /*******************  Bit definition for TIM2_INTFR register  *****************/

--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -241,6 +241,183 @@ typedef struct
 } PFIC_Type;
 #endif /* __ASSEMBLER__*/
 
+#ifdef CH570_CH572
+typedef struct {
+    __IO uint32_t CTRL;
+} CMP_TypeDef;
+#endif
+
+typedef struct {
+#if defined(CH570_CH572)
+    __IO uint16_t PA_INT_EN;        // 0H
+    uint16_t RESERVED0;             // 2H
+    __IO uint16_t PA_INT_MODE;      // 4H
+    __IO uint16_t PA_INT_EDGE_TYPE; // 6H
+    uint32_t RESERVED1;             // 8H
+    __IO uint16_t PA_INT_IF;        // CH
+    uint16_t RESERVED2;             // EH
+#else
+    __IO uint16_t PA_INT_EN;        // 0H
+    __IO uint16_t PB_INT_EN;        // 2H
+    __IO uint16_t PA_INT_MODE;      // 4H
+    __IO uint16_t PB_INT_MODE;      // 6H
+#if defined(CH591_CH592)
+    __IO uint16_t PA_INT_EDGE_TYPE; // 8H
+    __IO uint16_t PB_INT_EDGE_TYPE; // AH
+#else
+    uint32_t RESERVED0;             // 8H
+#endif
+    __IO uint16_t PA_INT_IF;        // CH
+    __IO uint16_t PB_INT_IF;        // EH
+#endif
+    __IO uint32_t PA_DIR;           // 10H
+    __IO uint32_t PA_PIN;           // 14H
+    __IO uint32_t PA_OUT;           // 18H
+    __IO uint32_t PA_CLR;           // 1CH
+    __IO uint32_t PA_PU;            // 20H
+    __IO uint32_t PA_PD_DRV;        // 24H
+    __IO uint32_t PA_SET;           // 28H
+#if defined(CH571_CH573) || defined(CH582_CH583) || defined(CH584_CH585) || defined(CH591_CH592)
+    uint32_t RESERVED1;             // 2CH
+    __IO uint32_t PB_DIR;           // 30H
+    __IO uint32_t PB_PIN;           // 34H
+    __IO uint32_t PB_OUT;           // 38H
+    __IO uint32_t PB_CLR;           // 3CH
+    __IO uint32_t PB_PU;            // 40H
+    __IO uint32_t PB_PD_DRV;        // 44H
+    __IO uint32_t PB_SET;           // 48H
+#endif
+} GPIO_TypeDef;
+
+#ifndef CH571_CH573
+typedef struct {
+    __IO uint16_t CTRL1;         // 0H
+    uint16_t RESERVED0;          // 2H
+    __IO uint16_t CTRL2;         // 4H
+    uint16_t RESERVED1;          // 6H
+    __IO uint16_t OADDR1;        // 8H
+    uint16_t RESERVED2;          // AH
+    __IO uint16_t OADDR2;        // CH
+    uint16_t RESERVED3;          // EH
+    __IO uint16_t DATAR;         // 10H
+    uint16_t RESERVED4;          // 12H
+    __IO uint16_t STAR1;         // 14H
+    uint16_t RESERVED5;          // 16H
+    __IO uint16_t STAR2;         // 18H
+    uint16_t RESERVED6;          // 1AH
+    __IO uint16_t CKCFGR;        // 1CH
+    uint16_t RESERVED7;          // 1EH
+    __IO uint16_t RTR;           // 20H
+} I2C_TypeDef;
+#endif
+
+#ifdef CH570_CH572
+typedef struct {
+    __IO uint16_t CTRL;          // 0H
+    __IO uint8_t INT_EN;         // 2H
+    __IO uint8_t INT_FLAG;       // 3H
+    __IO uint16_t SCAN_NUMB;     // 4H
+} KeyScan_TypeDef;
+#endif
+
+typedef struct {
+    __IO uint8_t OUT_EN;         // 0H
+    __IO uint8_t OUT_POLAR;      // 1H
+    __IO uint8_t CONFIG;         // 2H
+#ifdef CH570_CH572
+    __IO uint8_t DMA_CTRL;       // 3H
+    __IO uint8_t PWM1_DATA;      // 4H
+    __IO uint8_t PWM2_DATA;      // 5H
+    __IO uint8_t PWM3_DATA;      // 6H
+    uint8_t RESERVED0[5];        // 7H
+    __IO uint8_t INT_EN;         // CH
+    __IO uint8_t INT_FLAG;       // DH
+    uint16_t RESERVED1;          // EH
+    __IO uint8_t PWM4_DATA;      // 10H
+    __IO uint8_t PWM5_DATA;      // 11H
+    uint16_t RESERVED2;          // 12H
+    __IO uint16_t CYC_VALUE;     // 14H
+    __IO uint16_t CYC1_VALUE;    // 16H
+    __IO uint16_t CLOCK_DIV;     // 18H
+    uint16_t RESERVED3;          // 1AH
+    __IO uint32_t DMA_NOW;       // 1CH
+    __IO uint32_t DMA_BEG;       // 20H
+    __IO uint32_t DMA_END;       // 24H
+#else
+    __IO uint8_t CLOCK_DIV;      // 3H
+    __IO uint8_t PWM4_DATA;      // 4H
+    __IO uint8_t PWM5_DATA;      // 5H
+    __IO uint8_t PWM6_DATA;      // 6H
+    __IO uint8_t PWM7_DATA;      // 7H
+    __IO uint8_t PWM8_DATA;      // 8H
+    __IO uint8_t PWM9_DATA;      // 9H
+    __IO uint8_t PWM10_DATA;     // AH
+    __IO uint8_t PWM11_DATA;     // BH
+    __IO uint8_t INT_CTRL;       // CH
+#if defined(CH584_CH585) || defined(CH591_CH592)
+    uint8_t RESERVED0[3];        // DH
+    __IO uint32_t REG_DATA8;     // 10H
+    __IO uint32_t REG_CYCLE;     // 14H
+#endif
+#endif
+} PWM_TypeDef;
+
+typedef struct {
+    __IO uint8_t CTRL_MOD;         // 0H
+    __IO uint8_t CTRL_CFG;         // 1H
+    __IO uint8_t INTER_EN;         // 2H
+    __IO uint8_t CLKDIV_SLAVE_PRE; // 3H
+    __IO uint8_t BUFFER;           // 4H
+    __IO uint8_t RUN_FLAG;         // 5H
+    __IO uint8_t INT_FLAG;         // 6H
+    __IO uint8_t FIFO_COUNT;       // 7H
+#ifdef CH570_CH572
+    __IO uint8_t INT_TYPE;         // 8H
+    __IO uint8_t INTER1_EN;        // 9H
+    __IO uint8_t INTER1_FLAG;      // AH
+#else
+    uint8_t RESERVED0[3];          // 8H
+#endif
+    __IO uint16_t TOTAL_CNT;       // CH
+    uint16_t RESERVED1;            // EH
+    __IO uint8_t FIFO;             // 10H
+    uint8_t RESERVED2[2];          // 11H
+    __IO uint8_t COUNT1;           // 13H
+    __IO uint16_t DMA_NOW;         // 14H
+    uint16_t RESERVED3;            // 16H
+    __IO uint16_t DMA_BEG;         // 18H
+    uint16_t RESERVED4;            // 1AH
+    __IO uint16_t DMA_END;         // 1CH
+} SPI_TypeDef;
+
+typedef struct {
+    __IO uint8_t CTRL_MOD;       // 0H
+    __IO uint8_t CTRL_DMA;       // 1H
+    __IO uint8_t INTER_EN;       // 2H
+    uint8_t RESERVED0;           // 3H
+    __IO uint8_t PWM_MOD;        // 4H
+    uint8_t RESERVED1;           // 5H
+    __IO uint8_t INT_FLAG;       // 6H
+    __IO uint8_t FIFO_COUNT;     // 7H
+    __IO uint32_t COUNT;         // 8H
+    __IO uint32_t CNT_END;       // CH
+    __IO uint32_t FIFO;          // 10H
+    __IO uint16_t DMA_NOW;       // 14H
+    uint16_t RESERVED2;          // 16H
+    __IO uint16_t DMA_BEG;       // 18H
+    uint16_t RESERVED3;          // 1AH
+    __IO uint16_t DMA_END;       // 1CH
+#if defined(CH570_CH572)
+    uint16_t RESERVED4;          // 1EH
+    __IO uint8_t ENC_REG_CTRL;   // 20H
+    __IO uint8_t ENC_INTER_EN;   // 21H
+    __IO uint8_t ENC_INTER_FLAG; // 22H
+    uint8_t RESERVED5;           // 23H
+    __IO uint32_t ENC_REG_CEND;  // 24H
+    __IO uint32_t ENC_REG_CCNT;  // 28H
+#endif
+} TMR_TypeDef;
+
 typedef struct {
     __IO uint8_t MCR;
     __IO uint8_t IER;
@@ -257,7 +434,7 @@ typedef struct {
     __IO uint16_t DL;
     __IO uint8_t DIV;
     __IO uint8_t ADR;
-} UART_Typedef;
+} UART_TypeDef;
 
 
 #ifdef __ASSEMBLER__
@@ -1145,6 +1322,8 @@ typedef enum
 #define R32_ENC_REG_CEND    (*((vu32*)0x40002424))
 #define R32_ENC_REG_CCNT    (*((vu32*)0x40002428))
 #define BA_TMR              ((vu8*)0x40002400)        // point TMR base address
+
+#define TMR                 ((TMR_TypeDef*)BA_TMR)
 #else
 
 /* Timer0 register */
@@ -1234,6 +1413,11 @@ typedef enum
 #define BA_TMR1             ((vu8*)0x40002400)        // point TMR1 base address
 #define BA_TMR2             ((vu8*)0x40002800)        // point TMR2 base address
 #define BA_TMR3             ((vu8*)0x40002C00)        // point TMR3 base address
+
+#define TMR0                ((TMR_TypeDef*)BA_TMR0)
+#define TMR1                ((TMR_TypeDef*)BA_TMR1)
+#define TMR2                ((TMR_TypeDef*)BA_TMR2)
+#define TMR3                ((TMR_TypeDef*)BA_TMR3)
 #endif
 
 #define TMR_FIFO_SIZE       8                         // timer FIFO size (depth)
@@ -1431,11 +1615,11 @@ typedef enum
 #define UART_II_MODEM_CHG   0x00                      // RO, UART0 interrupt by modem status change
 #define UART_II_NO_INTER    0x01                      // RO, no UART interrupt is pending
 
-#define UART                ((UART_Typedef*)BA_UART)
-#define UART0                ((UART_Typedef*)BA_UART0)
-#define UART1                ((UART_Typedef*)BA_UART1)
-#define UART2                ((UART_Typedef*)BA_UART2)
-#define UART3                ((UART_Typedef*)BA_UART3)
+#define UART                ((UART_TypeDef*)BA_UART)
+#define UART0               ((UART_TypeDef*)BA_UART0)
+#define UART1               ((UART_TypeDef*)BA_UART1)
+#define UART2               ((UART_TypeDef*)BA_UART2)
+#define UART3               ((UART_TypeDef*)BA_UART3)
 
 /* SPI0 register */
 #define R32_SPI0_CONTROL    (*((vu32*)0x40004000))    // RW, SPI0 control
@@ -1537,6 +1721,9 @@ typedef enum
 #define SPI_DMA_BEG         0x18
 #define SPI_DMA_END         0x1C
 
+#define SPI0                ((SPI_TypeDef*)BA_SPI0)
+#define SPI1                ((SPI_TypeDef*)BA_SPI1)
+
 /* I2C register */
 #define R16_I2C_CTRL1       (*((vu16*)0x40004800))    // RW, I2C control 1
 #define R16_I2C_CTRL2       (*((vu16*)0x40004804))    // RW, I2C control 2
@@ -1611,6 +1798,10 @@ typedef enum
 #define  RB_I2C_F_S         0x8000                    // RW, I2C master mode selection: 0=standard mode, 1=fast mode
 #define I2C_RTR             32
 #define  RB_I2C_TRISE       0x003F                    // RW, Maximum rise time in Fm/Sm mode (Master mode)
+
+#ifndef CH571_CH573
+#define I2C                 ((I2C_TypeDef*)BA_I2C)
+#endif
 
 #ifdef CH57x
 /* PWM1/2/3/4/5/register */
@@ -1758,6 +1949,8 @@ typedef enum
 #define PWM10_DATA_HOLD     10
 #define PWM11_DATA_HOLD     11
 #endif
+
+#define PWMX                ((PWM_TypeDef*)BA_PWMX)
 
 #ifdef CH584_CH585
 /* LCD register */


### PR DESCRIPTION
Update the HAL to https://github.com/cnlohr/ch32fun/commit/012754ac4dcd72c7eed949fa29c701bdb0b53d59, including CH5xx register structures.

Apply minor local changes by replacing `asm` with `__ASM`, as it causes compilation errors (at least with the C17 standard). `__ASM` is defined in `ch32fun.h`. However, upstream owner prefers using `asm` in new code.

Note: I need this for (attempted) upstreaming of the nanoCH57x board port. Thanks :blush: 