### PR TITLE
hal: wch: update HAL to latest upstream (2026-07-03)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# hal_wch
+
+Header-only HAL for WCH SoCs in Zephyr.
+
+This repo should directly follow the headers in [ch32fun](https://github.com/cnlohr/ch32fun)

--- a/ch32fun/ch32fun.h
+++ b/ch32fun/ch32fun.h
@@ -144,6 +144,10 @@
 	#define FUNCONF_ENABLE_HPE 0
 #endif
 
+#ifndef FUNCONF_TINYVECTOR
+	#define FUNCONF_TINYVECTOR 0
+#endif
+
 #if FUNCONF_ENABLE_HPE == 1
 	#define INTERRUPT_DECORATOR  __attribute__((interrupt("WCH-Interrupt-fast")))
 #else
@@ -1024,7 +1028,13 @@ void funAnalogInit( void );
 // Be sure to call funAnalogInit first.
 int funAnalogRead( int nAnalogNumber );
 
-void handle_reset()            __attribute__((naked)) __attribute((section(".text.handle_reset"))) __attribute__((used));
+#if FUNCONF_CUSTOM_MTVEC
+	void handle_reset( void ) __attribute__((naked))  __attribute__((section(".init"))) __attribute__((used));
+#else
+	void handle_reset( void ) __attribute__((naked))  __attribute__((section(".text.handle_reset"))) __attribute__((used));
+#endif
+
+
 void DefaultIRQHandler( void ) __attribute__((section(VECTOR_HANDLER_SECTION))) __attribute__((naked)) __attribute__((used));
 // used to clear the CSS flag in case of clock fail switch
 #if defined(FUNCONF_USE_CLK_SEC) && FUNCONF_USE_CLK_SEC

--- a/ch32fun/ch32h41xhw.h
+++ b/ch32fun/ch32h41xhw.h
@@ -13646,7 +13646,11 @@ typedef enum
 #ifndef __ASSEMBLER__
 
 /* Output Maximum frequency selection */
+
+#ifndef __ZEPHYR__
 #warning "Speeds on H41x have their own register, dont concat in CFGLR"
+#endif
+
 typedef enum
 {
 	GPIO_Speed_10MHz = 0,

--- a/ch32fun/ch5xxhw.h
+++ b/ch32fun/ch5xxhw.h
@@ -326,20 +326,38 @@ typedef struct {
     __IO uint8_t CONFIG;         // 2H
 #ifdef CH570_CH572
     __IO uint8_t DMA_CTRL;       // 3H
-    __IO uint8_t PWM1_DATA;      // 4H
-    __IO uint8_t PWM2_DATA;      // 5H
-    __IO uint8_t PWM3_DATA;      // 6H
-    uint8_t RESERVED0[5];        // 7H
+    __packed union {
+        __packed struct {
+            __IO uint8_t PWM1_R8_DATA;   // 4H
+            __IO uint8_t PWM2_R8_DATA;   // 5H
+            __IO uint8_t PWM3_R8_DATA;   // 6H
+            uint8_t RESERVED0[3];        // 7H
+        };
+        __packed struct {
+            __IO uint16_t PWM1_R16_DATA; // 4H
+            __IO uint16_t PWM2_R16_DATA; // 6H
+            __IO uint16_t PWM3_R16_DATA; // 8H
+        };
+    };
+    uint16_t RESERVED1;          // AH
     __IO uint8_t INT_EN;         // CH
     __IO uint8_t INT_FLAG;       // DH
-    uint16_t RESERVED1;          // EH
-    __IO uint8_t PWM4_DATA;      // 10H
-    __IO uint8_t PWM5_DATA;      // 11H
-    uint16_t RESERVED2;          // 12H
+    uint16_t RESERVED2;          // EH
+    __packed union {
+        __packed struct {
+            __IO uint8_t PWM4_R8_DATA; // 10H
+            __IO uint8_t PWM5_R8_DATA; // 11H
+            uint16_t RESERVED3;        // 12H
+        };
+        __packed struct {
+            __IO uint16_t PWM4_R16_DATA; // 10H
+            __IO uint16_t PWM5_R16_DATA; // 12H
+        };
+    };
     __IO uint16_t CYC_VALUE;     // 14H
     __IO uint16_t CYC1_VALUE;    // 16H
     __IO uint16_t CLOCK_DIV;     // 18H
-    uint16_t RESERVED3;          // 1AH
+    uint16_t RESERVED4;          // 1AH
     __IO uint32_t DMA_NOW;       // 1CH
     __IO uint32_t DMA_BEG;       // 20H
     __IO uint32_t DMA_END;       // 24H
@@ -355,7 +373,7 @@ typedef struct {
     __IO uint8_t PWM11_DATA;     // BH
     __IO uint8_t INT_CTRL;       // CH
 #if defined(CH584_CH585) || defined(CH591_CH592)
-    uint8_t RESERVED0[3];        // DH
+    uint8_t RESERVED5[3];        // DH
     __IO uint32_t REG_DATA8;     // 10H
     __IO uint32_t REG_CYCLE;     // 14H
 #endif
@@ -558,6 +576,7 @@ typedef enum
 	CLK_SOURCE_HSE_PLL_24MHz = (0x300 | 0x40 | 13),
 	CLK_SOURCE_HSE_PLL_19_5MHz = (0x300 | 0x40 | 16),
 	CLK_SOURCE_HSE_PLL_13MHz = (0x300 | 0x40 | 24),
+	#define CLK_SOURCE_PLL_60MHz 0xFF // Dummy to catch wrong clock setting for this chip
 #elif defined(CH591_CH592)
 	CLK_SOURCE_LSI = 0x00,
 	CLK_SOURCE_LSE,


### PR DESCRIPTION
Update the hal to: https://github.com/cnlohr/ch32fun/commit/7a511663dc8f47e4d2c556961111698b7ed7eccd.

Mitigates the warning problem in this PR: https://github.com/zephyrproject-rtos/zephyr/pull/111725